### PR TITLE
Exclude Dependabot PRs from analysis

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,6 +45,7 @@ jobs:
   sonarcloud:
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
I excluded Dependabot PRs from Sonarqube analysis because we do not have new code in these PRs. Furthermore, we got an authentication error and exclusion is the recommended workaround ([see here](https://community.sonarsource.com/t/youre-not-authorized-to-run-analysis-and-github-bots/41994/4))